### PR TITLE
Add linktree-style /me page with QR code

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1757,7 +1757,7 @@ button:focus {
 
 .profile-header {
     text-align: center;
-    padding: 40px 30px 30px;
+    padding: 50px 30px 40px;
     background: linear-gradient(135deg, var(--primary-color) 0%, var(--accent-color) 100%);
     color: white;
     display: flex;
@@ -1766,11 +1766,11 @@ button:focus {
 }
 
 .avatar-flip-container {
-    perspective: 1000px;
-    width: 120px;
-    height: 120px;
+    perspective: 1200px;
+    width: 150px;
+    height: 150px;
     cursor: pointer;
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
 }
 
 .flip-card-inner {
@@ -1778,7 +1778,7 @@ button:focus {
     width: 100%;
     height: 100%;
     text-align: center;
-    transition: transform 0.6s;
+    transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
     transform-style: preserve-3d;
 }
 
@@ -1795,6 +1795,7 @@ button:focus {
     backface-visibility: hidden;
     border-radius: 50%;
     overflow: hidden;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
 }
 
 .flip-card-front {
@@ -1802,12 +1803,12 @@ button:focus {
 }
 
 .flip-card-back {
-    background: #1e3a8a;
+    background: #ffffff;
     transform: rotateY(180deg);
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 5px;
+    padding: 10px;
 }
 
 .qr-embedded {
@@ -1817,9 +1818,9 @@ button:focus {
 }
 
 .qr-embedded img {
-    width: 110px !important;
-    height: 110px !important;
-    border-radius: 8px;
+    width: 130px !important;
+    height: 130px !important;
+    border-radius: 0;
 }
 
 .profile-info {
@@ -1936,21 +1937,24 @@ button:focus {
 /* Desktop/Landscape Styles */
 @media (min-width: 900px) {
     .linktree-card {
-        max-width: 1000px !important;
+        max-width: 1100px !important;
         display: grid !important;
-        grid-template-columns: 1fr 350px !important;
+        grid-template-columns: 1.3fr 1fr !important;
         gap: 0 !important;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.12);
     }
 
     .linktree-main {
         border-right: 1px solid var(--border-color);
+        padding: 0;
     }
 
     .profile-header {
         text-align: left;
-        padding: 40px 40px 25px;
+        padding: 50px 50px 30px;
         flex-direction: row;
-        gap: 2rem;
+        gap: 2.5rem;
+        background: linear-gradient(135deg, var(--primary-color) 0%, var(--accent-color) 100%);
     }
 
     .avatar-flip-container {
@@ -1979,41 +1983,46 @@ button:focus {
     }
 
     .linktree-name {
-        font-size: 2.2rem;
-        margin-bottom: 0.6rem;
+        font-size: 2.5rem;
+        margin-bottom: 0.8rem;
+        letter-spacing: -0.5px;
     }
 
     .linktree-title {
-        font-size: 1.1rem;
+        font-size: 1.15rem;
+        font-weight: 400;
+        opacity: 0.95;
     }
 
     .desktop-bio {
         display: block;
-        padding: 0 40px 40px;
+        padding: 35px 50px 45px;
         margin-top: 0;
-        line-height: 1.8;
+        line-height: 1.9;
     }
 
     .desktop-bio p {
         margin: 0;
         color: var(--text-secondary);
-        font-size: 1rem;
+        font-size: 1.05rem;
+        font-weight: 400;
     }
 
     .linktree-links {
-        padding: 20px 40px 40px;
+        padding: 30px 50px 50px;
         grid-template-columns: repeat(2, 1fr);
         display: grid;
+        gap: 1.2rem;
     }
 
     .linktree-sidebar {
         display: block;
-        padding: 40px 30px;
+        padding: 50px 40px 50px 45px;
         background: var(--background-gray);
     }
 
     .sidebar-section {
-        margin-bottom: 2.5rem;
+        margin-bottom: 3rem;
     }
 
     .sidebar-section:last-child {
@@ -2022,15 +2031,18 @@ button:focus {
 
     .sidebar-section h3 {
         font-family: var(--font-serif);
-        font-size: 1.2rem;
+        font-size: 1.35rem;
         color: var(--primary-color);
-        margin-bottom: 0.8rem;
+        margin-bottom: 1rem;
+        font-weight: 600;
+        letter-spacing: -0.3px;
     }
 
     .sidebar-section p {
         color: var(--text-secondary);
-        line-height: 1.6;
-        font-size: 0.95rem;
+        line-height: 1.7;
+        font-size: 1rem;
+        font-weight: 400;
     }
 
     .expertise-list {
@@ -2039,24 +2051,27 @@ button:focus {
     }
 
     .expertise-list li {
-        padding: 0.6rem 0;
+        padding: 0.8rem 0;
         color: var(--text-primary);
         position: relative;
-        padding-left: 1.5rem;
+        padding-left: 1.8rem;
+        font-weight: 500;
+        font-size: 1rem;
     }
 
     .expertise-list li::before {
-        content: '•';
-        color: var(--primary-color);
+        content: '✓';
+        color: var(--accent-color);
         position: absolute;
         left: 0;
         font-weight: bold;
+        font-size: 0.9rem;
     }
 
     .impact-stats {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
-        gap: 1rem;
+        gap: 1.5rem;
         text-align: center;
     }
 
@@ -2064,42 +2079,72 @@ button:focus {
         display: flex;
         flex-direction: column;
         align-items: center;
+        padding: 1.5rem 0.5rem;
+        background: var(--card-background);
+        border-radius: 12px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        transition: var(--transition-medium);
+    }
+
+    .stat-item:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
     }
 
     .stat-number {
         font-family: var(--font-serif);
-        font-size: 1.8rem;
+        font-size: 2.2rem;
         font-weight: 700;
         color: var(--primary-color);
+        margin-bottom: 0.4rem;
     }
 
     .stat-label {
-        font-size: 0.85rem;
+        font-size: 0.9rem;
         color: var(--text-secondary);
-        margin-top: 0.3rem;
+        font-weight: 500;
     }
 
     .sidebar-section i {
-        color: var(--primary-color);
-        margin-right: 0.5rem;
+        color: var(--accent-color);
+        margin-right: 0.7rem;
     }
 
     .work-status {
-        font-size: 0.85rem;
+        font-size: 0.95rem;
         color: var(--accent-color);
-        font-weight: 500;
-        margin-top: 0.5rem;
+        font-weight: 600;
+        margin-top: 1rem;
+        padding-top: 1rem;
+        border-top: 1px solid var(--border-color);
     }
 
     .qr-section {
         border: none;
-        padding: 30px 0 0;
+        padding: 35px 0 0;
         background: transparent;
         text-align: center;
     }
 
+    .qr-section .qr-code {
+        background: var(--card-background);
+        padding: 15px;
+        border-radius: 12px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        display: inline-block;
+    }
+
+    .qr-section .qr-code img {
+        border: none;
+        box-shadow: none;
+        border-radius: 4px;
+    }
+
     .qr-text {
-        margin-top: 0.8rem;
+        margin-top: 1.2rem;
+        font-size: 0.95rem;
+        font-weight: 500;
+        color: var(--text-secondary);
     }
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1728,3 +1728,173 @@ button:focus {
         --border-color: #000000;
     }
 }
+
+/* Linktree Page Styles */
+.linktree-container {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 100px 20px 40px;
+    background: linear-gradient(135deg, var(--background-light) 0%, var(--background-gray) 100%);
+}
+
+.linktree-card {
+    width: 100%;
+    max-width: 400px;
+    background: var(--card-background);
+    border-radius: 20px;
+    box-shadow: 0 10px 40px var(--shadow-medium);
+    border: 1px solid var(--border-color);
+    overflow: hidden;
+    animation: fadeInUp 0.6s ease;
+}
+
+.profile-header {
+    text-align: center;
+    padding: 40px 30px 30px;
+    background: linear-gradient(135deg, var(--primary-color) 0%, var(--accent-color) 100%);
+    color: white;
+}
+
+.linktree-avatar {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 4px solid white;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+    margin-bottom: 1rem;
+}
+
+.linktree-name {
+    font-family: var(--font-serif);
+    font-size: 1.8rem;
+    margin-bottom: 0.5rem;
+    color: white;
+}
+
+.linktree-title {
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.9);
+    font-weight: 300;
+}
+
+.linktree-links {
+    padding: 30px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.linktree-link {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+    background: var(--background-light);
+    border: 2px solid var(--border-color);
+    border-radius: 12px;
+    text-decoration: none;
+    color: var(--text-primary);
+    font-weight: 500;
+    transition: var(--transition-fast);
+    position: relative;
+}
+
+.linktree-link:hover {
+    transform: translateY(-2px);
+    border-color: var(--primary-color);
+    box-shadow: 0 5px 20px var(--shadow-light);
+    background: var(--background-gray);
+}
+
+.linktree-link i:first-child {
+    font-size: 1.3rem;
+    color: var(--primary-color);
+    width: 24px;
+    text-align: center;
+}
+
+.linktree-link span {
+    flex: 1;
+}
+
+.linktree-icon-right {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.qr-section {
+    text-align: center;
+    padding: 20px 30px 40px;
+    border-top: 1px solid var(--border-color);
+    background: var(--background-gray);
+}
+
+.qr-code {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0 auto 1rem;
+}
+
+.qr-code img {
+    border-radius: 8px;
+    border: 4px solid white;
+    box-shadow: 0 4px 12px var(--shadow-light);
+}
+
+.qr-text {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin: 0;
+}
+
+/* Responsive Linktree */
+@media (max-width: 480px) {
+    .linktree-container {
+        padding: 80px 15px 30px;
+    }
+
+    .linktree-card {
+        max-width: 100%;
+    }
+
+    .profile-header {
+        padding: 30px 20px 20px;
+    }
+
+    .linktree-avatar {
+        width: 100px;
+        height: 100px;
+    }
+
+    .linktree-name {
+        font-size: 1.5rem;
+    }
+
+    .linktree-title {
+        font-size: 0.85rem;
+    }
+
+    .linktree-links {
+        padding: 20px 15px;
+        gap: 0.75rem;
+    }
+
+    .linktree-link {
+        padding: 0.9rem 1.2rem;
+        font-size: 0.95rem;
+    }
+}
+
+/* Dark mode linktree adjustments */
+[data-theme="dark"] .linktree-link {
+    background: var(--card-background);
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
+[data-theme="dark"] .linktree-link:hover {
+    background: rgba(30, 58, 138, 0.1);
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1750,11 +1750,20 @@ button:focus {
     animation: fadeInUp 0.6s ease;
 }
 
+.linktree-main {
+    padding: 0;
+}
+
 .profile-header {
     text-align: center;
     padding: 40px 30px 30px;
     background: linear-gradient(135deg, var(--primary-color) 0%, var(--accent-color) 100%);
     color: white;
+    display: block;
+}
+
+.profile-info {
+    margin-top: 1rem;
 }
 
 .linktree-avatar {
@@ -1778,6 +1787,15 @@ button:focus {
     font-size: 0.95rem;
     color: rgba(255, 255, 255, 0.9);
     font-weight: 300;
+}
+
+.desktop-bio {
+    display: none;
+    padding: 20px 30px;
+    text-align: center;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    border-bottom: 1px solid var(--border-color);
 }
 
 .linktree-links {
@@ -1825,6 +1843,10 @@ button:focus {
     color: var(--text-secondary);
 }
 
+.linktree-sidebar {
+    display: none;
+}
+
 .qr-section {
     text-align: center;
     padding: 20px 30px 40px;
@@ -1849,6 +1871,154 @@ button:focus {
     color: var(--text-secondary);
     font-size: 0.85rem;
     margin: 0;
+}
+
+/* Desktop/Landscape Styles */
+@media (min-width: 992px) {
+    .linktree-card {
+        max-width: 1000px;
+        display: grid;
+        grid-template-columns: 1fr 350px;
+        gap: 0;
+    }
+
+    .linktree-main {
+        border-right: 1px solid var(--border-color);
+    }
+
+    .profile-header {
+        text-align: left;
+        padding: 40px 40px 20px;
+        display: flex;
+        align-items: center;
+        gap: 2rem;
+    }
+
+    .profile-info {
+        margin-top: 0;
+        text-align: left;
+    }
+
+    .linktree-avatar {
+        margin-bottom: 0;
+        width: 140px;
+        height: 140px;
+    }
+
+    .linktree-name {
+        font-size: 2.2rem;
+    }
+
+    .linktree-title {
+        font-size: 1.1rem;
+    }
+
+    .desktop-bio {
+        display: block;
+        padding: 0 40px 30px;
+    }
+
+    .linktree-links {
+        padding: 20px 40px 40px;
+        grid-template-columns: repeat(2, 1fr);
+        display: grid;
+    }
+
+    .linktree-sidebar {
+        display: block;
+        padding: 40px 30px;
+        background: var(--background-gray);
+    }
+
+    .sidebar-section {
+        margin-bottom: 2.5rem;
+    }
+
+    .sidebar-section:last-child {
+        margin-bottom: 0;
+    }
+
+    .sidebar-section h3 {
+        font-family: var(--font-serif);
+        font-size: 1.2rem;
+        color: var(--primary-color);
+        margin-bottom: 0.8rem;
+    }
+
+    .sidebar-section p {
+        color: var(--text-secondary);
+        line-height: 1.6;
+        font-size: 0.95rem;
+    }
+
+    .expertise-list {
+        list-style: none;
+        padding: 0;
+    }
+
+    .expertise-list li {
+        padding: 0.6rem 0;
+        color: var(--text-primary);
+        position: relative;
+        padding-left: 1.5rem;
+    }
+
+    .expertise-list li::before {
+        content: '•';
+        color: var(--primary-color);
+        position: absolute;
+        left: 0;
+        font-weight: bold;
+    }
+
+    .impact-stats {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1rem;
+        text-align: center;
+    }
+
+    .stat-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .stat-number {
+        font-family: var(--font-serif);
+        font-size: 1.8rem;
+        font-weight: 700;
+        color: var(--primary-color);
+    }
+
+    .stat-label {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+        margin-top: 0.3rem;
+    }
+
+    .sidebar-section i {
+        color: var(--primary-color);
+        margin-right: 0.5rem;
+    }
+
+    .work-status {
+        font-size: 0.85rem;
+        color: var(--accent-color);
+        font-weight: 500;
+        margin-top: 0.5rem;
+    }
+
+    .qr-section {
+        border: none;
+        padding: 30px 0 0;
+        background: transparent;
+        text-align: center;
+    }
+
+    .qr-text {
+        margin-top: 0.8rem;
+    }
 }
 
 /* Responsive Linktree */
@@ -1886,6 +2056,13 @@ button:focus {
     .linktree-link {
         padding: 0.9rem 1.2rem;
         font-size: 0.95rem;
+    }
+}
+
+/* Tablet styles */
+@media (min-width: 481px) and (max-width: 991px) {
+    .linktree-card {
+        max-width: 500px;
     }
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1765,62 +1765,20 @@ button:focus {
     align-items: center;
 }
 
-.avatar-flip-container {
-    perspective: 1200px;
+.linktree-avatar {
     width: 150px;
     height: 150px;
-    cursor: pointer;
-    margin-bottom: 1.5rem;
-}
-
-.flip-card-inner {
-    position: relative;
-    width: 100%;
-    height: 100%;
-    text-align: center;
-    transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-    transform-style: preserve-3d;
-}
-
-.avatar-flip-container.flipped .flip-card-inner {
-    transform: rotateY(180deg);
-}
-
-.flip-card-front,
-.flip-card-back {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    -webkit-backface-visibility: hidden;
-    backface-visibility: hidden;
     border-radius: 50%;
-    overflow: hidden;
+    object-fit: cover;
+    border: 5px solid white;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+    margin-bottom: 1.5rem;
+    cursor: pointer;
+    transition: transform 0.3s ease;
 }
 
-.flip-card-front {
-    background: transparent;
-}
-
-.flip-card-back {
-    background: #ffffff;
-    transform: rotateY(180deg);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 10px;
-}
-
-.qr-embedded {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.qr-embedded img {
-    width: 130px !important;
-    height: 130px !important;
-    border-radius: 0;
+.linktree-avatar:hover {
+    transform: scale(1.05);
 }
 
 .profile-info {
@@ -1934,6 +1892,127 @@ button:focus {
     margin: 0;
 }
 
+/* QR Modal Styles */
+.qr-modal {
+    display: none;
+    position: fixed;
+    z-index: 3000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(5px);
+    align-items: center;
+    justify-content: center;
+    animation: fadeIn 0.3s ease;
+}
+
+.qr-modal.active {
+    display: flex;
+}
+
+.qr-modal-content {
+    background: var(--card-background);
+    border-radius: 20px;
+    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.25);
+    max-width: 90%;
+    width: 400px;
+    animation: scaleIn 0.3s ease;
+}
+
+.qr-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 25px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.qr-modal-header h3 {
+    font-family: var(--font-serif);
+    color: var(--primary-color);
+    font-size: 1.4rem;
+    margin: 0;
+}
+
+.qr-modal-close {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 1.5rem;
+    cursor: pointer;
+    padding: 5px;
+    transition: var(--transition-fast);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+}
+
+.qr-modal-close:hover {
+    background: var(--background-gray);
+    color: var(--primary-color);
+}
+
+.qr-modal-body {
+    padding: 30px 25px;
+    text-align: center;
+}
+
+.qr-code-large {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0 auto 20px;
+    padding: 15px;
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.qr-code-large img {
+    border: none;
+    box-shadow: none;
+    border-radius: 4px;
+}
+
+.qr-modal-text {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin: 0 0 10px;
+}
+
+.qr-url {
+    color: var(--primary-color);
+    font-size: 0.9rem;
+    font-weight: 500;
+    margin: 0;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes scaleIn {
+    from {
+        opacity: 0;
+        transform: scale(0.9);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
 /* Desktop/Landscape Styles */
 @media (min-width: 900px) {
     .linktree-card {
@@ -1957,29 +2036,15 @@ button:focus {
         background: linear-gradient(135deg, var(--primary-color) 0%, var(--accent-color) 100%);
     }
 
-    .avatar-flip-container {
+    .linktree-avatar {
         margin-bottom: 0;
+        width: 160px;
+        height: 160px;
         cursor: default;
     }
 
-    .flip-card-inner {
-        transition: none;
-    }
-
-    .flip-card-back {
-        display: none;
-    }
-
-    .profile-info {
-        margin-top: 0;
-        text-align: left;
-        flex: 1;
-    }
-
-    .linktree-avatar {
-        margin-bottom: 0;
-        width: 140px;
-        height: 140px;
+    .linktree-avatar:hover {
+        transform: none;
     }
 
     .linktree-name {
@@ -2163,8 +2228,9 @@ button:focus {
     }
 
     .linktree-avatar {
-        width: 100px;
-        height: 100px;
+        width: 120px;
+        height: 120px;
+        border-width: 4px;
     }
 
     .linktree-name {
@@ -2201,4 +2267,17 @@ button:focus {
 
 [data-theme="dark"] .linktree-link:hover {
     background: rgba(30, 58, 138, 0.1);
+}
+
+/* Dark mode modal adjustments */
+[data-theme="dark"] .qr-modal-content {
+    background: var(--card-background);
+}
+
+[data-theme="dark"] .qr-modal-close:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+[data-theme="dark"] .qr-code-large {
+    background: #ffffff;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1748,6 +1748,7 @@ button:focus {
     border: 1px solid var(--border-color);
     overflow: hidden;
     animation: fadeInUp 0.6s ease;
+    display: block;
 }
 
 .linktree-main {
@@ -1874,12 +1875,12 @@ button:focus {
 }
 
 /* Desktop/Landscape Styles */
-@media (min-width: 992px) {
+@media (min-width: 900px) {
     .linktree-card {
-        max-width: 1000px;
-        display: grid;
-        grid-template-columns: 1fr 350px;
-        gap: 0;
+        max-width: 1000px !important;
+        display: grid !important;
+        grid-template-columns: 1fr 350px !important;
+        gap: 0 !important;
     }
 
     .linktree-main {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1760,7 +1760,66 @@ button:focus {
     padding: 40px 30px 30px;
     background: linear-gradient(135deg, var(--primary-color) 0%, var(--accent-color) 100%);
     color: white;
-    display: block;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.avatar-flip-container {
+    perspective: 1000px;
+    width: 120px;
+    height: 120px;
+    cursor: pointer;
+    margin-bottom: 1rem;
+}
+
+.flip-card-inner {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    transition: transform 0.6s;
+    transform-style: preserve-3d;
+}
+
+.avatar-flip-container.flipped .flip-card-inner {
+    transform: rotateY(180deg);
+}
+
+.flip-card-front,
+.flip-card-back {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+    border-radius: 50%;
+    overflow: hidden;
+}
+
+.flip-card-front {
+    background: transparent;
+}
+
+.flip-card-back {
+    background: #1e3a8a;
+    transform: rotateY(180deg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 5px;
+}
+
+.qr-embedded {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.qr-embedded img {
+    width: 110px !important;
+    height: 110px !important;
+    border-radius: 8px;
 }
 
 .profile-info {
@@ -1889,15 +1948,28 @@ button:focus {
 
     .profile-header {
         text-align: left;
-        padding: 40px 40px 20px;
-        display: flex;
-        align-items: center;
+        padding: 40px 40px 25px;
+        flex-direction: row;
         gap: 2rem;
+    }
+
+    .avatar-flip-container {
+        margin-bottom: 0;
+        cursor: default;
+    }
+
+    .flip-card-inner {
+        transition: none;
+    }
+
+    .flip-card-back {
+        display: none;
     }
 
     .profile-info {
         margin-top: 0;
         text-align: left;
+        flex: 1;
     }
 
     .linktree-avatar {
@@ -1908,6 +1980,7 @@ button:focus {
 
     .linktree-name {
         font-size: 2.2rem;
+        margin-bottom: 0.6rem;
     }
 
     .linktree-title {
@@ -1916,7 +1989,15 @@ button:focus {
 
     .desktop-bio {
         display: block;
-        padding: 0 40px 30px;
+        padding: 0 40px 40px;
+        margin-top: 0;
+        line-height: 1.8;
+    }
+
+    .desktop-bio p {
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: 1rem;
     }
 
     .linktree-links {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2174,43 +2174,6 @@ button:focus {
         color: var(--accent-color);
         margin-right: 0.7rem;
     }
-
-    .work-status {
-        font-size: 0.95rem;
-        color: var(--accent-color);
-        font-weight: 600;
-        margin-top: 1rem;
-        padding-top: 1rem;
-        border-top: 1px solid var(--border-color);
-    }
-
-    .qr-section {
-        border: none;
-        padding: 35px 0 0;
-        background: transparent;
-        text-align: center;
-    }
-
-    .qr-section .qr-code {
-        background: var(--card-background);
-        padding: 15px;
-        border-radius: 12px;
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-        display: inline-block;
-    }
-
-    .qr-section .qr-code img {
-        border: none;
-        box-shadow: none;
-        border-radius: 4px;
-    }
-
-    .qr-text {
-        margin-top: 1.2rem;
-        font-size: 0.95rem;
-        font-weight: 500;
-        color: var(--text-secondary);
-    }
 }
 
 /* Responsive Linktree */

--- a/me.html
+++ b/me.html
@@ -9,16 +9,7 @@ permalink: /me/
     <div class="linktree-card">
         <div class="linktree-main">
             <div class="profile-header">
-                <div class="avatar-flip-container" id="avatar-flip">
-                    <div class="flip-card-inner">
-                        <div class="flip-card-front">
-                            <img src="/assets/images/profile-photo.webp" alt="Treta Sharma" class="linktree-avatar" width="120" height="120">
-                        </div>
-                        <div class="flip-card-back">
-                            <div class="qr-embedded" id="qrcode-embedded"></div>
-                        </div>
-                    </div>
-                </div>
+                <img src="/assets/images/profile-photo.webp" alt="Treta Sharma" class="linktree-avatar" width="150" height="150" id="profile-avatar">
                 <div class="profile-info">
                     <h1 class="linktree-name">Treta Sharma</h1>
                     <p class="linktree-title">Learning Sciences & Educational Technology Specialist</p>
@@ -123,40 +114,83 @@ permalink: /me/
     </div>
 </div>
 
+<div id="qr-modal" class="qr-modal">
+    <div class="qr-modal-content">
+        <div class="qr-modal-header">
+            <h3>Scan to Connect</h3>
+            <button class="qr-modal-close" aria-label="Close modal">
+                <i class="fas fa-times"></i>
+            </button>
+        </div>
+        <div class="qr-modal-body">
+            <div id="qrcode-modal" class="qr-code-large"></div>
+            <p class="qr-modal-text">Scan this QR code with your phone camera to save my contact information</p>
+            <p class="qr-url">tretasharma.com/me</p>
+        </div>
+    </div>
+</div>
+
 <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         if (typeof QRCode !== 'undefined') {
             const qrContainer = document.getElementById('qrcode');
-            const qrEmbedded = document.getElementById('qrcode-embedded');
+            const qrModalContainer = document.getElementById('qrcode-modal');
 
             if (qrContainer) {
                 new QRCode(qrContainer, {
                     text: 'https://tretasharma.com/me/',
                     width: 150,
                     height: 150,
-                    colorDark: '#1e3a8a',
+                    colorDark: '#000000',
                     colorLight: '#ffffff',
                     correctLevel: QRCode.CorrectLevel.H
                 });
             }
 
-            if (qrEmbedded) {
-                new QRCode(qrEmbedded, {
+            if (qrModalContainer) {
+                new QRCode(qrModalContainer, {
                     text: 'https://tretasharma.com/me/',
-                    width: 130,
-                    height: 130,
-                    colorDark: '#1e3a8a',
+                    width: 250,
+                    height: 250,
+                    colorDark: '#000000',
                     colorLight: '#ffffff',
                     correctLevel: QRCode.CorrectLevel.H
                 });
             }
 
-            const flipContainer = document.getElementById('avatar-flip');
-            if (flipContainer) {
-                flipContainer.addEventListener('click', function() {
-                    this.classList.toggle('flipped');
+            const profileAvatar = document.getElementById('profile-avatar');
+            const qrModal = document.getElementById('qr-modal');
+            const modalCloseBtn = document.querySelector('.qr-modal-close');
+
+            if (profileAvatar && qrModal) {
+                profileAvatar.addEventListener('click', function() {
+                    qrModal.classList.add('active');
+                    document.body.style.overflow = 'hidden';
                 });
+            }
+
+            if (qrModal) {
+                qrModal.addEventListener('click', function(e) {
+                    if (e.target === qrModal) {
+                        closeModal();
+                    }
+                });
+            }
+
+            if (modalCloseBtn) {
+                modalCloseBtn.addEventListener('click', closeModal);
+            }
+
+            document.addEventListener('keydown', function(e) {
+                if (e.key === 'Escape' && qrModal) {
+                    closeModal();
+                }
+            });
+
+            function closeModal() {
+                qrModal.classList.remove('active');
+                document.body.style.overflow = '';
             }
         }
     });

--- a/me.html
+++ b/me.html
@@ -1,0 +1,82 @@
+---
+layout: default
+title: Connect with Treta
+description: Get in touch with Treta Sharma - all social links, email, phone, and contact information in one place
+permalink: /me/
+---
+
+<div class="linktree-container">
+    <div class="linktree-card">
+        <div class="profile-header">
+            <img src="/assets/images/profile-photo.webp" alt="Treta Sharma" class="linktree-avatar" width="120" height="120">
+            <h1 class="linktree-name">Treta Sharma</h1>
+            <p class="linktree-title">Learning Sciences & Educational Technology Specialist</p>
+        </div>
+
+        <div class="linktree-links">
+            <a href="https://linkedin.com/in/tretasharma" target="_blank" rel="noopener" class="linktree-link">
+                <i class="fab fa-linkedin"></i>
+                <span>LinkedIn</span>
+                <i class="fas fa-external-link-alt linktree-icon-right"></i>
+            </a>
+
+            <a href="mailto:tretasharma@gmail.com" class="linktree-link">
+                <i class="fas fa-envelope"></i>
+                <span>Email</span>
+                <i class="fas fa-external-link-alt linktree-icon-right"></i>
+            </a>
+
+            <a href="tel:+17737397326" class="linktree-link">
+                <i class="fas fa-phone"></i>
+                <span>Phone</span>
+                <i class="fas fa-external-link-alt linktree-icon-right"></i>
+            </a>
+
+            <a href="https://medium.com/@tretasharma" target="_blank" rel="noopener" class="linktree-link">
+                <i class="fab fa-medium"></i>
+                <span>Medium Blog</span>
+                <i class="fas fa-external-link-alt linktree-icon-right"></i>
+            </a>
+
+            <a href="https://x.com/sharmatreta" target="_blank" rel="noopener" class="linktree-link">
+                <i class="fab fa-twitter"></i>
+                <span>Twitter / X</span>
+                <i class="fas fa-external-link-alt linktree-icon-right"></i>
+            </a>
+
+            <a href="/assets/files/Treta-Sharma-Learning-Design-Resume.pdf" target="_blank" class="linktree-link">
+                <i class="fas fa-file-pdf"></i>
+                <span>Download Resume</span>
+                <i class="fas fa-download linktree-icon-right"></i>
+            </a>
+
+            <a href="/" class="linktree-link">
+                <i class="fas fa-globe"></i>
+                <span>Full Portfolio Website</span>
+                <i class="fas fa-external-link-alt linktree-icon-right"></i>
+            </a>
+        </div>
+
+        <div class="qr-section">
+            <div id="qrcode" class="qr-code"></div>
+            <p class="qr-text">Scan to save my contact info</p>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const qrContainer = document.getElementById('qrcode');
+        if (qrContainer && typeof QRCode !== 'undefined') {
+            new QRCode(qrContainer, {
+                text: 'https://tretasharma.com/me/',
+                width: 150,
+                height: 150,
+                colorDark: '#1e3a8a',
+                colorLight: '#ffffff',
+                correctLevel: QRCode.CorrectLevel.H
+            });
+        }
+    });
+</script>

--- a/me.html
+++ b/me.html
@@ -7,62 +7,129 @@ permalink: /me/
 
 <div class="linktree-container">
     <div class="linktree-card">
-        <div class="profile-header">
-            <img src="/assets/images/profile-photo.webp" alt="Treta Sharma" class="linktree-avatar" width="120" height="120">
-            <h1 class="linktree-name">Treta Sharma</h1>
-            <p class="linktree-title">Learning Sciences & Educational Technology Specialist</p>
+        <div class="linktree-main">
+            <div class="profile-header">
+                <img src="/assets/images/profile-photo.webp" alt="Treta Sharma" class="linktree-avatar" width="120" height="120">
+                <div class="profile-info">
+                    <h1 class="linktree-name">Treta Sharma</h1>
+                    <p class="linktree-title">Learning Sciences & Educational Technology Specialist</p>
+                </div>
+            </div>
+
+            <div class="desktop-bio">
+                <p>Learning and instructional specialist with 8 years of experience. Passionate about creating, empowering, and transforming learning environments through technology, training, and curriculum development.</p>
+            </div>
+
+            <div class="linktree-links">
+                <a href="https://linkedin.com/in/tretasharma" target="_blank" rel="noopener" class="linktree-link">
+                    <i class="fab fa-linkedin"></i>
+                    <span>LinkedIn</span>
+                    <i class="fas fa-external-link-alt linktree-icon-right"></i>
+                </a>
+
+                <a href="mailto:tretasharma@gmail.com" class="linktree-link">
+                    <i class="fas fa-envelope"></i>
+                    <span>Email</span>
+                    <i class="fas fa-external-link-alt linktree-icon-right"></i>
+                </a>
+
+                <a href="tel:+17737397326" class="linktree-link">
+                    <i class="fas fa-phone"></i>
+                    <span>Phone</span>
+                    <i class="fas fa-external-link-alt linktree-icon-right"></i>
+                </a>
+
+                <a href="https://medium.com/@tretasharma" target="_blank" rel="noopener" class="linktree-link">
+                    <i class="fab fa-medium"></i>
+                    <span>Medium Blog</span>
+                    <i class="fas fa-external-link-alt linktree-icon-right"></i>
+                </a>
+
+                <a href="https://x.com/sharmatreta" target="_blank" rel="noopener" class="linktree-link">
+                    <i class="fab fa-twitter"></i>
+                    <span>Twitter / X</span>
+                    <i class="fas fa-external-link-alt linktree-icon-right"></i>
+                </a>
+
+                <a href="/assets/files/Treta-Sharma-Learning-Design-Resume.pdf" target="_blank" class="linktree-link">
+                    <i class="fas fa-file-pdf"></i>
+                    <span>Download Resume</span>
+                    <i class="fas fa-download linktree-icon-right"></i>
+                </a>
+
+                <a href="/" class="linktree-link">
+                    <i class="fas fa-globe"></i>
+                    <span>Full Portfolio Website</span>
+                    <i class="fas fa-external-link-alt linktree-icon-right"></i>
+                </a>
+            </div>
         </div>
 
-        <div class="linktree-links">
-            <a href="https://linkedin.com/in/tretasharma" target="_blank" rel="noopener" class="linktree-link">
-                <i class="fab fa-linkedin"></i>
-                <span>LinkedIn</span>
-                <i class="fas fa-external-link-alt linktree-icon-right"></i>
-            </a>
+        <div class="linktree-sidebar">
+            <div class="sidebar-section">
+                <h3>Current Focus</h3>
+                <p>MS in Learning Sciences & Educational Technology at Northwestern University</p>
+            </div>
 
-            <a href="mailto:tretasharma@gmail.com" class="linktree-link">
-                <i class="fas fa-envelope"></i>
-                <span>Email</span>
-                <i class="fas fa-external-link-alt linktree-icon-right"></i>
-            </a>
+            <div class="sidebar-section">
+                <h3>Expertise</h3>
+                <ul class="expertise-list">
+                    <li>Educational Technology</li>
+                    <li>Curriculum Design</li>
+                    <li>Learning Analytics</li>
+                    <li>AI in Education</li>
+                    <li>Teacher Training</li>
+                </ul>
+            </div>
 
-            <a href="tel:+17737397326" class="linktree-link">
-                <i class="fas fa-phone"></i>
-                <span>Phone</span>
-                <i class="fas fa-external-link-alt linktree-icon-right"></i>
-            </a>
+            <div class="sidebar-section">
+                <h3>Impact</h3>
+                <div class="impact-stats">
+                    <div class="stat-item">
+                        <span class="stat-number">1.2M+</span>
+                        <span class="stat-label">Learners</span>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-number">8+</span>
+                        <span class="stat-label">Years Exp</span>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-number">3K+</span>
+                        <span class="stat-label">Institutions</span>
+                    </div>
+                </div>
+            </div>
 
-            <a href="https://medium.com/@tretasharma" target="_blank" rel="noopener" class="linktree-link">
-                <i class="fab fa-medium"></i>
-                <span>Medium Blog</span>
-                <i class="fas fa-external-link-alt linktree-icon-right"></i>
-            </a>
+            <div class="sidebar-section">
+                <h3>Location</h3>
+                <p><i class="fas fa-map-marker-alt"></i> Mountain View, CA, USA</p>
+                <p class="work-status">Authorized to work in the US</p>
+            </div>
 
-            <a href="https://x.com/sharmatreta" target="_blank" rel="noopener" class="linktree-link">
-                <i class="fab fa-twitter"></i>
-                <span>Twitter / X</span>
-                <i class="fas fa-external-link-alt linktree-icon-right"></i>
-            </a>
-
-            <a href="/assets/files/Treta-Sharma-Learning-Design-Resume.pdf" target="_blank" class="linktree-link">
-                <i class="fas fa-file-pdf"></i>
-                <span>Download Resume</span>
-                <i class="fas fa-download linktree-icon-right"></i>
-            </a>
-
-            <a href="/" class="linktree-link">
-                <i class="fas fa-globe"></i>
-                <span>Full Portfolio Website</span>
-                <i class="fas fa-external-link-alt linktree-icon-right"></i>
-            </a>
-        </div>
-
-        <div class="qr-section">
-            <div id="qrcode" class="qr-code"></div>
-            <p class="qr-text">Scan to save my contact info</p>
+            <div class="qr-section">
+                <div id="qrcode" class="qr-code"></div>
+                <p class="qr-text">Scan to save my contact</p>
+            </div>
         </div>
     </div>
 </div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const qrContainer = document.getElementById('qrcode');
+        if (qrContainer && typeof QRCode !== 'undefined') {
+            new QRCode(qrContainer, {
+                text: 'https://tretasharma.com/me/',
+                width: 150,
+                height: 150,
+                colorDark: '#1e3a8a',
+                colorLight: '#ffffff',
+                correctLevel: QRCode.CorrectLevel.H
+            });
+        }
+    });
+</script>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 <script>

--- a/me.html
+++ b/me.html
@@ -103,12 +103,6 @@ permalink: /me/
             <div class="sidebar-section">
                 <h3>Location</h3>
                 <p><i class="fas fa-map-marker-alt"></i> Mountain View, CA, USA</p>
-                <p class="work-status">Authorized to work in the US</p>
-            </div>
-
-            <div class="qr-section">
-                <div id="qrcode" class="qr-code"></div>
-                <p class="qr-text">Scan to save my contact</p>
             </div>
         </div>
     </div>

--- a/me.html
+++ b/me.html
@@ -9,7 +9,16 @@ permalink: /me/
     <div class="linktree-card">
         <div class="linktree-main">
             <div class="profile-header">
-                <img src="/assets/images/profile-photo.webp" alt="Treta Sharma" class="linktree-avatar" width="120" height="120">
+                <div class="avatar-flip-container" id="avatar-flip">
+                    <div class="flip-card-inner">
+                        <div class="flip-card-front">
+                            <img src="/assets/images/profile-photo.webp" alt="Treta Sharma" class="linktree-avatar" width="120" height="120">
+                        </div>
+                        <div class="flip-card-back">
+                            <div class="qr-embedded" id="qrcode-embedded"></div>
+                        </div>
+                    </div>
+                </div>
                 <div class="profile-info">
                     <h1 class="linktree-name">Treta Sharma</h1>
                     <p class="linktree-title">Learning Sciences & Educational Technology Specialist</p>
@@ -117,16 +126,38 @@ permalink: /me/
 <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
-        const qrContainer = document.getElementById('qrcode');
-        if (qrContainer && typeof QRCode !== 'undefined') {
-            new QRCode(qrContainer, {
-                text: 'https://tretasharma.com/me/',
-                width: 150,
-                height: 150,
-                colorDark: '#1e3a8a',
-                colorLight: '#ffffff',
-                correctLevel: QRCode.CorrectLevel.H
-            });
+        if (typeof QRCode !== 'undefined') {
+            const qrContainer = document.getElementById('qrcode');
+            const qrEmbedded = document.getElementById('qrcode-embedded');
+
+            if (qrContainer) {
+                new QRCode(qrContainer, {
+                    text: 'https://tretasharma.com/me/',
+                    width: 150,
+                    height: 150,
+                    colorDark: '#1e3a8a',
+                    colorLight: '#ffffff',
+                    correctLevel: QRCode.CorrectLevel.H
+                });
+            }
+
+            if (qrEmbedded) {
+                new QRCode(qrEmbedded, {
+                    text: 'https://tretasharma.com/me/',
+                    width: 120,
+                    height: 120,
+                    colorDark: '#ffffff',
+                    colorLight: '#1e3a8a',
+                    correctLevel: QRCode.CorrectLevel.H
+                });
+            }
+
+            const flipContainer = document.getElementById('avatar-flip');
+            if (flipContainer) {
+                flipContainer.addEventListener('click', function() {
+                    this.classList.toggle('flipped');
+                });
+            }
         }
     });
 </script>

--- a/me.html
+++ b/me.html
@@ -130,20 +130,3 @@ permalink: /me/
         }
     });
 </script>
-
-<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        const qrContainer = document.getElementById('qrcode');
-        if (qrContainer && typeof QRCode !== 'undefined') {
-            new QRCode(qrContainer, {
-                text: 'https://tretasharma.com/me/',
-                width: 150,
-                height: 150,
-                colorDark: '#1e3a8a',
-                colorLight: '#ffffff',
-                correctLevel: QRCode.CorrectLevel.H
-            });
-        }
-    });
-</script>

--- a/me.html
+++ b/me.html
@@ -144,10 +144,10 @@ permalink: /me/
             if (qrEmbedded) {
                 new QRCode(qrEmbedded, {
                     text: 'https://tretasharma.com/me/',
-                    width: 120,
-                    height: 120,
-                    colorDark: '#ffffff',
-                    colorLight: '#1e3a8a',
+                    width: 130,
+                    height: 130,
+                    colorDark: '#1e3a8a',
+                    colorLight: '#ffffff',
                     correctLevel: QRCode.CorrectLevel.H
                 });
             }


### PR DESCRIPTION
## Summary
- Created new `/me` endpoint with a beautiful linktree-style visiting card layout
- Added all social links (LinkedIn, Twitter/X, Medium)
- Added contact information (email, phone)
- Added link to download resume
- Added link to full portfolio website
- Included QR code pointing to `/me` page for easy mobile access
- Styled with responsive design matching the site theme
- Uses QRCode.js library for QR generation

## Features
- **Beautiful visiting card design**: Portrait-style layout with profile photo, name, and title
- **All contact links in one place**: LinkedIn, Email, Phone, Medium, Twitter/X
- **Resume download**: Direct link to PDF resume
- **QR Code**: Automatically generated QR code that points to the /me page for quick scanning
- **Responsive design**: Works beautifully on mobile and desktop
- **Dark mode support**: Automatically adapts to site's dark mode theme
- **Smooth animations**: Fade-in animation on page load and hover effects on links

## How to test locally
```bash
bundle exec jekyll serve
```
Then visit: `http://localhost:4000/me/`

## Live preview (after merge)
https://tretasharma.com/me/